### PR TITLE
added log streaming sub module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -7,7 +7,7 @@ data "aws_vpc" "selected" {
 # the subnets to be used based on the Tier tag
 data "aws_subnet_ids" "selected" {
   vpc_id = data.aws_vpc.selected.id
-  tags   = {
+  tags = {
     Tier = var.assign_public_ip ? "public" : "private"
   }
 }
@@ -49,7 +49,7 @@ resource "aws_ecs_service" "this" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.this.arn
+    registry_arn   = aws_service_discovery_service.this.arn
     container_name = var.container_name
   }
 
@@ -157,9 +157,9 @@ resource "aws_alb_listener_rule" "private" {
 }
 
 locals {
-  root_path      = split("/", abspath(path.root))
-  tf_stack       = join("/", slice(local.root_path, length(local.root_path) - 1, length(local.root_path)))
-  default_tags   = {
+  root_path = split("/", abspath(path.root))
+  tf_stack  = join("/", slice(local.root_path, length(local.root_path) - 1, length(local.root_path)))
+  default_tags = {
     managed_by = "terraform",
     source     = "github.com/stroeer/buzzgate"
     tf_stack   = local.tf_stack,
@@ -186,4 +186,11 @@ module "code_deploy" {
   task_role_arn              = aws_iam_role.ecs_task_role.arn
   tags                       = local.default_tags
   ecr_repository_name        = aws_ecr_repository.this.name
+}
+
+module "logs" {
+  source = "./modules/logs"
+
+  service_name = var.service_name
+  tags         = local.default_tags
 }

--- a/modules/logs/main.tf
+++ b/modules/logs/main.tf
@@ -1,0 +1,140 @@
+locals {
+  index_name = "${var.service_name}-app"
+}
+
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+# see https://docs.aws.amazon.com/firehose/latest/dev/controlling-access.html#using-iam-es
+data "aws_iam_policy_document" "stream_policy" {
+  count = var.enabled ? 1 : 0
+  statement {
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:GetBucketLocation",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:PutObject"
+    ]
+    resources = [
+      "arn:aws:s3:::${aws_s3_bucket.firehose[count.index].id}",
+      "arn:aws:s3:::${aws_s3_bucket.firehose[count.index].id}/*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "es:DescribeElasticsearchDomain",
+      "es:DescribeElasticsearchDomains",
+      "es:DescribeElasticsearchDomainConfig",
+      "es:ESHttpPost",
+      "es:ESHttpPut"
+
+    ]
+    resources = [
+      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}",
+      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/*"
+    ]
+  }
+
+  statement {
+    actions = [
+      "es:ESHttpGet"
+    ]
+
+    resources = [
+      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/_all/_settings",
+      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/_cluster/stats",
+      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/${local.index_name}*/_mapping/type-name",
+      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/_nodes",
+      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/_nodes/stats",
+      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/_nodes/*/stats",
+      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/_stats",
+      "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/${local.index_name}*/_stats"
+    ]
+  }
+}
+
+data "aws_iam_policy_document" "firehose_policy" {
+  count = var.enabled ? 1 : 0
+  statement {
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["firehose.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "firehose_role" {
+  count              = var.enabled ? 1 : 0
+  assume_role_policy = data.aws_iam_policy_document.firehose_policy[count.index].json
+  description        = "IAM permissions for ${var.service_name} as Firehose delivery stream to Elasticsearch."
+  name               = "firehose_elasticsearch_role_${var.service_name}"
+  tags               = var.tags
+}
+
+
+resource "aws_iam_policy" "stream_policy" {
+  count  = var.enabled ? 1 : 0
+  policy = data.aws_iam_policy_document.stream_policy[count.index].json
+}
+
+resource "aws_iam_role_policy_attachment" "stream_policy_attachment" {
+  count      = var.enabled ? 1 : 0
+  role       = aws_iam_role.firehose_role[count.index].name
+  policy_arn = aws_iam_policy.stream_policy[count.index].arn
+}
+
+resource "aws_s3_bucket" "firehose" {
+  count  = var.enabled ? 1 : 0
+  acl    = "private"
+  bucket = "${var.service_name}-failed-documents-${data.aws_caller_identity.current.account_id}-${data.aws_region.current.name}"
+  tags   = var.tags
+}
+
+resource "aws_s3_bucket_public_access_block" "firehose" {
+  count                   = var.enabled ? 1 : 0
+  block_public_acls       = true
+  block_public_policy     = true
+  bucket                  = aws_s3_bucket.firehose[count.index].id
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+data "aws_elasticsearch_domain" "elasticsearch" {
+  count       = var.enabled ? 1 : 0
+  domain_name = var.domain_name
+}
+
+resource "aws_kinesis_firehose_delivery_stream" "elasticsearch_stream" {
+  count       = var.enabled ? 1 : 0
+  name        = "${var.service_name}-stream"
+  destination = "elasticsearch"
+  tags        = var.tags
+
+  elasticsearch_configuration {
+    domain_arn            = data.aws_elasticsearch_domain.elasticsearch[count.index].arn
+    index_name            = local.index_name
+    index_rotation_period = "OneDay"
+    role_arn              = aws_iam_role.firehose_role[count.index].arn
+    s3_backup_mode        = "FailedDocumentsOnly"
+
+    cloudwatch_logging_options {
+      enabled = false
+    }
+  }
+
+  s3_configuration {
+    bucket_arn         = aws_s3_bucket.firehose[count.index].arn
+    compression_format = "GZIP"
+    role_arn           = aws_iam_role.firehose_role[count.index].arn
+    # kms_key_arn = "todo with default key from data to enable encryption"
+
+    cloudwatch_logging_options {
+      enabled = false
+    }
+  }
+}

--- a/modules/logs/outputs.tf
+++ b/modules/logs/outputs.tf
@@ -1,0 +1,4 @@
+output "kinesis_firehose_delivery_stream_name" {
+  description = "The name to identify the stream."
+  value       = element(aws_kinesis_firehose_delivery_stream.elasticsearch_stream.*.name, 0)
+}

--- a/modules/logs/variables.tf
+++ b/modules/logs/variables.tf
@@ -1,0 +1,29 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "service_name" {
+  description = "Name of the service to collect log events for. This will be used as the Elasticsearch index name and for IAM configuration."
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "domain_name" {
+  default     = "application-logs"
+  description = "The name of an existing Elasticsearch domain used as destination for the Firehose delivery stream."
+}
+
+variable "enabled" {
+  default     = true
+  description = "Conditionally enables this module (and all it's ressources)."
+}
+
+variable "tags" {
+  default     = {}
+  description = "A mapping of tags to assign to the Kinesis Firehose resource."
+  type        = map(string)
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,10 +5,15 @@ output "ecr_repo_arn" {
 
 output "public_dns" {
   description = "Public DNS entry."
-  value = "${aws_route53_record.external.name}.${data.aws_route53_zone.external.name}"
+  value       = "${aws_route53_record.external.name}.${data.aws_route53_zone.external.name}"
 }
 
 output "private_dns" {
   description = "Private DNS entry."
-  value = "${aws_route53_record.internal.name}.${data.aws_route53_zone.internal.name}"
+  value       = "${aws_route53_record.internal.name}.${data.aws_route53_zone.internal.name}"
+}
+
+output "kinesis_firehose_delivery_stream_name" {
+  description = "The name of the Kinesis Firehose delivery stream."
+  value       = module.logs.kinesis_firehose_delivery_stream_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,10 +1,10 @@
 variable "cluster_id" {
-  type = string
+  type        = string
   description = "The ECS cluster id that should run this service"
 }
 
 variable "service_name" {
-  type = string
+  type        = string
   description = "The service name. Will also be used as Route53 DNS entry."
 }
 
@@ -26,18 +26,18 @@ variable "container_definitions" {
 }
 
 variable "assign_public_ip" {
-  type    = bool
-  default = false
+  type        = bool
+  default     = false
   description = "As Fargate does not support IPv6 yet, this is the only way to enable internet access for the service."
 }
 
 variable "alb_listener_priority" {
-  type = number
+  type        = number
   description = "Ordering of listers, must be unique."
 }
 
 variable "health_check_endpoint" {
-  type = string
+  type        = string
   description = "Endpoint (/health) that will be probed by the LB to determine the service's health."
 }
 
@@ -55,8 +55,8 @@ module {
 
 */
 variable "policy_document" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
   description = "AWS Policy JSON describing the permissions required for this service."
 }
 
@@ -73,14 +73,14 @@ CPU value 	    | Memory value (MiB)
 */
 
 variable "cpu" {
-  type    = number
-  default = 256
+  type        = number
+  default     = 256
   description = "Amount of CPU required by this service. 1024 == 1 vCPU"
 }
 
 variable "memory" {
-  type    = number
-  default = 512
+  type        = number
+  default     = 512
   description = "Amount of memory [MB] is required by this service."
 }
 
@@ -91,7 +91,12 @@ variable "desired_count" {
 }
 
 variable "create_deployment_pipeline" {
-  type = bool
-  default = true
+  type        = bool
+  default     = true
   description = "Creates a deploy pipeline from ECR trigger"
+}
+
+variable "create_log_streaming" {
+  default     = true
+  description = "Creates a Kinesis Firehose delivery stream for streaming application logs to an existing Elasticsearch domain."
 }


### PR DESCRIPTION
Added (sub) module to create Kinesis Firehose Delivery streams for an application to stream app logs to an (existing) AWS elasticsearch domain using Firelens/Fluend-Bit.

Todo:
- example
- documentation
- default permission to put log events