### PR TITLE
extracted ecr as submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ No requirements.
 | create\_deployment\_pipeline | Creates a deploy pipeline from ECR trigger. | `bool` | `true` | no |
 | create\_log\_streaming | Creates a Kinesis Firehose delivery stream for streaming application logs to an existing Elasticsearch domain. | `bool` | `true` | no |
 | desired\_count | Desired count of services to be started/running. | `number` | `0` | no |
+| ecr | ECR repository configuration. | <pre>object({<br>    image_scanning_configuration = object({<br>      scan_on_push = bool<br>    })<br>    image_tag_mutability = string,<br>  })</pre> | <pre>{<br>  "image_scanning_configuration": {<br>    "scan_on_push": false<br>  },<br>  "image_tag_mutability": "MUTABLE"<br>}</pre> | no |
 | health\_check\_endpoint | Endpoint (/health) that will be probed by the LB to determine the service's health. | `string` | n/a | yes |
 | memory | Amount of memory [MB] is required by this service. | `number` | `512` | no |
 | policy\_document | AWS Policy JSON describing the permissions required for this service. | `string` | `""` | no |
@@ -38,7 +39,7 @@ No requirements.
 
 | Name | Description |
 |------|-------------|
-| ecr\_repo\_arn | ECR repository |
+| ecr\_repository\_arn | Full ARN of the ECR repository |
 | kinesis\_firehose\_delivery\_stream\_name | The name of the Kinesis Firehose delivery stream. |
 | private\_dns | Private DNS entry. |
 | public\_dns | Public DNS entry. |

--- a/docs/part2.md
+++ b/docs/part2.md
@@ -23,6 +23,7 @@ No requirements.
 | create\_deployment\_pipeline | Creates a deploy pipeline from ECR trigger. | `bool` | `true` | no |
 | create\_log\_streaming | Creates a Kinesis Firehose delivery stream for streaming application logs to an existing Elasticsearch domain. | `bool` | `true` | no |
 | desired\_count | Desired count of services to be started/running. | `number` | `0` | no |
+| ecr | ECR repository configuration. | <pre>object({<br>    image_scanning_configuration = object({<br>      scan_on_push = bool<br>    })<br>    image_tag_mutability = string,<br>  })</pre> | <pre>{<br>  "image_scanning_configuration": {<br>    "scan_on_push": false<br>  },<br>  "image_tag_mutability": "MUTABLE"<br>}</pre> | no |
 | health\_check\_endpoint | Endpoint (/health) that will be probed by the LB to determine the service's health. | `string` | n/a | yes |
 | memory | Amount of memory [MB] is required by this service. | `number` | `512` | no |
 | policy\_document | AWS Policy JSON describing the permissions required for this service. | `string` | `""` | no |
@@ -33,7 +34,7 @@ No requirements.
 
 | Name | Description |
 |------|-------------|
-| ecr\_repo\_arn | ECR repository |
+| ecr\_repository\_arn | Full ARN of the ECR repository |
 | kinesis\_firehose\_delivery\_stream\_name | The name of the Kinesis Firehose delivery stream. |
 | private\_dns | Private DNS entry. |
 | public\_dns | Public DNS entry. |

--- a/examples/public-service/main.tf
+++ b/examples/public-service/main.tf
@@ -39,4 +39,11 @@ module "service" {
   }
 ]
 DOC
+
+  ecr = {
+    image_tag_mutability = "IMMUTABLE"
+    image_scanning_configuration = {
+      scan_on_push = true
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -196,8 +196,13 @@ locals {
   container_name = var.container_name == "" ? var.service_name : var.container_name
 }
 
-resource "aws_ecr_repository" "this" {
-  name = var.service_name
+module "ecr" {
+  source = "./modules/ecr"
+
+  image_scanning_configuration = var.ecr.image_scanning_configuration
+  image_tag_mutability         = var.ecr.image_tag_mutability
+  name                         = var.service_name
+  tags                         = local.default_tags
 }
 
 module "code_deploy" {
@@ -206,7 +211,7 @@ module "code_deploy" {
 
   cluster_name        = var.cluster_id
   container_port      = var.container_port
-  ecr_repository_name = aws_ecr_repository.this.name
+  ecr_repository_name = module.ecr.name
   health_check_path   = var.health_check_endpoint
   listener_arns       = [data.aws_lb_listener.private.arn, data.aws_lb_listener.public.arn]
   service_name        = var.service_name

--- a/main.tf
+++ b/main.tf
@@ -210,14 +210,9 @@ module "code_deploy" {
   enabled = var.create_deployment_pipeline
 
   cluster_name        = var.cluster_id
-  container_port      = var.container_port
   ecr_repository_name = module.ecr.name
-  health_check_path   = var.health_check_endpoint
-  listener_arns       = [data.aws_lb_listener.private.arn, data.aws_lb_listener.public.arn]
   service_name        = var.service_name
   tags                = local.default_tags
-  task_role_arn       = aws_iam_role.ecs_task_role.arn
-  vpc_id              = data.aws_vpc.selected.id
 }
 
 module "logs" {

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,0 +1,9 @@
+resource "aws_ecr_repository" "this" {
+  name                 = var.name
+  image_tag_mutability = var.image_tag_mutability
+  tags                 = var.tags
+
+  image_scanning_configuration {
+    scan_on_push = var.image_scanning_configuration.scan_on_push
+  }
+}

--- a/modules/ecr/outputs.tf
+++ b/modules/ecr/outputs.tf
@@ -1,0 +1,19 @@
+output "arn" {
+  description = "Full ARN of the repository."
+  value       = aws_ecr_repository.this.arn
+}
+
+output "name" {
+  description = "The name of the repository."
+  value       = aws_ecr_repository.this.name
+}
+
+output "registry_id" {
+  description = "The registry ID where the repository was created."
+  value       = aws_ecr_repository.this.registry_id
+}
+
+output "repository_url" {
+  description = "The URL of the repository (in the form aws_account_id.dkr.ecr.region.amazonaws.com/repositoryName)."
+  value       = aws_ecr_repository.this.repository_url
+}

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,38 @@
+# ---------------------------------------------------------------------------------------------------------------------
+# REQUIRED PARAMETERS
+# You must provide a value for each of these parameters.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "name" {
+  description = "Name of the repository."
+  type        = string
+}
+
+# ---------------------------------------------------------------------------------------------------------------------
+# OPTIONAL PARAMETERS
+# These parameters have reasonable defaults.
+# ---------------------------------------------------------------------------------------------------------------------
+
+variable "image_scanning_configuration" {
+  description = "Configuration block that defines image scanning configuration for the repository. By default, image scanning must be manually triggered. See the ECR User Guide for more information about image scanning."
+  type = object({
+    scan_on_push = bool,
+  })
+
+  default = {
+    scan_on_push = false
+  }
+}
+
+variable "image_tag_mutability" {
+  default     = "MUTABLE"
+  description = "The tag mutability setting for the repository. Must be one of: MUTABLE or IMMUTABLE. Defaults to MUTABLE."
+  type        = string
+}
+
+variable "tags" {
+  default     = {}
+  description = "A mapping of tags to assign to the repository."
+  type        = map(string)
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
-output "ecr_repo_arn" {
-  description = "ECR repository"
-  value       = aws_ecr_repository.this.arn
+output "ecr_repository_arn" {
+  description = "Full ARN of the ECR repository"
+  value       = module.ecr.arn
 }
 
 output "kinesis_firehose_delivery_stream_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,25 @@ variable "desired_count" {
   description = "Desired count of services to be started/running."
 }
 
+variable "ecr" {
+  description = "ECR repository configuration."
+  type = object({
+    image_scanning_configuration = object({
+      scan_on_push = bool
+    })
+    image_tag_mutability = string,
+  })
+
+  # if you change any of the defaults, the whole configuration object needs to be provided. 
+  # https://github.com/hashicorp/terraform/issues/19898 will probably change this
+  default = {
+    image_scanning_configuration = {
+      scan_on_push = false
+    }
+    image_tag_mutability = "MUTABLE",
+  }
+}
+
 variable "memory" {
   default     = 512
   description = "Amount of memory [MB] is required by this service."


### PR DESCRIPTION
ecr resource is now a configurable sub-module

tags and name are not configurable to enforce our best practices

this also provides options to configure image scanning like proposed in #3
but without enabling it by default since this doesn't reflect the
terraform defaults.
